### PR TITLE
[codex] add Project Zomboid server channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ SECURITY.md                   # Security audit findings and vulnerability report
 | GENERAL         | #general-chat, #introductions, #off-topic, #bug-reports |
 | GAMING          | #gaming-general, #game-nights, #lan-events, 🔊 Gaming Lounge |
 | PRESERVATION    | #preservation-talk, #hardware-help, #software-help, 🔊 Preservation Lab |
+| PROJECT ZOMBOID | #zomboid-text, 🔊 Zomboid Voice                     |
 
 **Roles**: Admin · Moderator · Bot · Member
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,3 +74,40 @@ resource "discord_voice_channel" "voice" {
   name      = "voice"
   position  = 2
 }
+
+# ---------------------------------------------------------------------------
+# Channels — Project Zomboid
+# ---------------------------------------------------------------------------
+resource "discord_category_channel" "project_zomboid" {
+  server_id = var.server_id
+  name      = "PROJECT ZOMBOID"
+  position  = 3
+}
+
+resource "discord_text_channel" "zomboid_text" {
+  server_id = var.server_id
+  name      = "zomboid-text"
+  topic     = "Project Zomboid server details and event updates."
+  position  = 0
+  category  = discord_category_channel.project_zomboid.id
+}
+
+resource "discord_message" "zomboid_server_details" {
+  channel_id = discord_text_channel.zomboid_text.id
+  content    = <<-EOT
+    📣 **Project Zomboid Server Details**
+
+    Server: `windurst.ddns.net:16261`
+    Password: shared in this channel when rotated and pinned to the top.
+
+    Regular events will be announced here.
+  EOT
+  pinned     = true
+}
+
+resource "discord_voice_channel" "zomboid_voice" {
+  server_id = var.server_id
+  name      = "Zomboid Voice"
+  position  = 1
+  category  = discord_category_channel.project_zomboid.id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -35,8 +35,29 @@ output "channel_voice_id" {
   value       = discord_voice_channel.voice.id
 }
 
+# Project Zomboid
+output "category_project_zomboid_id" {
+  description = "ID of the PROJECT ZOMBOID category."
+  value       = discord_category_channel.project_zomboid.id
+}
+
+output "channel_zomboid_text_id" {
+  description = "ID of the #zomboid-text channel."
+  value       = discord_text_channel.zomboid_text.id
+}
+
+output "channel_zomboid_voice_id" {
+  description = "ID of the Zomboid voice channel."
+  value       = discord_voice_channel.zomboid_voice.id
+}
+
 # Pinned message IDs
 output "message_rules_id" {
   description = "ID of the pinned rule message in #text."
   value       = discord_message.rules_message.id
+}
+
+output "message_zomboid_server_details_id" {
+  description = "ID of the pinned Project Zomboid server details message in #zomboid-text."
+  value       = discord_message.zomboid_server_details.id
 }


### PR DESCRIPTION
## Summary
Add a new `PROJECT ZOMBOID` category with dedicated text and voice channels, plus a pinned server-details message for the community server.

## Why
This follows up on issue #33 and gives the Project Zomboid community a dedicated place for updates and voice chat.

## What changed
- Added a `PROJECT ZOMBOID` category
- Added `#zomboid-text` and `Zomboid Voice`
- Added a pinned message with the server address and rotation note
- Exported the new category/channel/message IDs in Terraform outputs
- Updated the server structure table in the README

## Validation
- Scoped the commit to the three intended files only
- `terraform fmt` could not be run in this container because the `terraform` binary is unavailable here

Closes #33