### PR TITLE
[codex] restore Project Zomboid event details

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ SECURITY.md                   # Security audit findings and vulnerability report
 | GENERAL         | #general-chat, #introductions, #off-topic, #bug-reports |
 | GAMING          | #gaming-general, #game-nights, #lan-events, 🔊 Gaming Lounge |
 | PRESERVATION    | #preservation-talk, #hardware-help, #software-help, 🔊 Preservation Lab |
-| PROJECT ZOMBOID | #zomboid-text, 🔊 Zomboid Voice                     |
+| PROJECT ZOMBOID | #project-zomboid, 🔊 Project Zomboid               |
 
 **Roles**: Admin · Moderator · Bot · Member
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,30 +84,29 @@ resource "discord_category_channel" "project_zomboid" {
   position  = 3
 }
 
-resource "discord_text_channel" "zomboid_text" {
+resource "discord_text_channel" "project_zomboid" {
   server_id = var.server_id
-  name      = "zomboid-text"
-  topic     = "Project Zomboid server details and event updates."
+  name      = "project-zomboid"
+  topic     = "Project Zomboid server info and coordination. Address: windurst.ddns.net:16261. Password shared here when rotated and pinned."
   position  = 0
   category  = discord_category_channel.project_zomboid.id
 }
 
-resource "discord_message" "zomboid_server_details" {
-  channel_id = discord_text_channel.zomboid_text.id
+resource "discord_message" "project_zomboid_details" {
+  channel_id = discord_text_channel.project_zomboid.id
   content    = <<-EOT
-    📣 **Project Zomboid Server Details**
+    🧟 **Project Zomboid Server**
 
-    Server: `windurst.ddns.net:16261`
-    Password: shared in this channel when rotated and pinned to the top.
-
-    Regular events will be announced here.
+    - Address: `windurst.ddns.net:16261`
+    - Password: A password is required; the current password will be shared in this channel and kept pinned when rotated.
+    - Notes: Event coordination and bot updates for the Zomboid server live here.
   EOT
   pinned     = true
 }
 
-resource "discord_voice_channel" "zomboid_voice" {
+resource "discord_voice_channel" "project_zomboid" {
   server_id = var.server_id
-  name      = "Zomboid Voice"
+  name      = "🔊 Project Zomboid"
   position  = 1
   category  = discord_category_channel.project_zomboid.id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -41,14 +41,14 @@ output "category_project_zomboid_id" {
   value       = discord_category_channel.project_zomboid.id
 }
 
-output "channel_zomboid_text_id" {
-  description = "ID of the #zomboid-text channel."
-  value       = discord_text_channel.zomboid_text.id
+output "channel_project_zomboid_text_id" {
+  description = "ID of the #project-zomboid text channel."
+  value       = discord_text_channel.project_zomboid.id
 }
 
-output "channel_zomboid_voice_id" {
-  description = "ID of the Zomboid voice channel."
-  value       = discord_voice_channel.zomboid_voice.id
+output "channel_project_zomboid_voice_id" {
+  description = "ID of the 🔊 Project Zomboid voice channel."
+  value       = discord_voice_channel.project_zomboid.id
 }
 
 # Pinned message IDs
@@ -57,7 +57,7 @@ output "message_rules_id" {
   value       = discord_message.rules_message.id
 }
 
-output "message_zomboid_server_details_id" {
-  description = "ID of the pinned Project Zomboid server details message in #zomboid-text."
-  value       = discord_message.zomboid_server_details.id
+output "message_project_zomboid_details_id" {
+  description = "ID of the pinned Project Zomboid server details message."
+  value       = discord_message.project_zomboid_details.id
 }


### PR DESCRIPTION
## Summary
Restore the more event-oriented Project Zomboid channel naming and pinned announcement copy.

## Why
The merged Zomboid update simplified the original wording too far and dropped the event-coordination flavor from the announcement. This follow-up restores the stronger community/event framing.

## What changed
- Renamed the Zomboid text and voice resources back to the original `project-zomboid` / `🔊 Project Zomboid` shape
- Restored the pinned message copy that calls out event coordination and bot updates
- Updated the README table to match the restored channel names
- Kept the PROJECT ZOMBOID category and outputs in place

## Validation
- Cherry-picked the restoration onto the latest `main`
- Scoped the change to the Zomboid files only
- Could not run `terraform fmt` in this container because the `terraform` binary is unavailable here